### PR TITLE
Fixed constant time comparsion for mixed data lens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,9 @@ documentation = "https://myfreeweb.github.io/autodocs/secstr/secstr"
 [lib]
 name = "secstr"
 
+[features]
+#optional benchmarks using nightly/unstable Bencher
+benchmark = []
+
 [dependencies]
 libc = "*"


### PR DESCRIPTION
Now the comparsion time is relative to the length
of the SecStr on the right hand side and
does not short cicuite if it has a different length.
(this prevents exposure of the secrets length)

Also a benchmark (hidden behind a feature flag)
was added. To run it use:
`cargo bench --features benchmark`

Note that it might make sense to document
that the fact, that on comparsions with different
length, the  righ hand side (RHS) is used to
determine the comparsion time means that
the "correct" SecStr should be on the left
hand side. E.g.:

``` rust
//good time is relative to passed_token.len()
expected_token.eq(passed_token);

//less good length might be exposed 
//(but harder then the short circuiting version)
passd_token.eq(expected_token);
```
