### PR TITLE
Add generic `SecVec` and `SecBox` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ impl<T> Encodable for SecVec<T> where T: Sized + Copy {
 
 #[cfg(test)]
 mod tests {
-    use super::SecStr;
+    use super::{SecStr, SecVec};
     
     #[test]
     fn test_basic() {
@@ -241,5 +241,17 @@ mod tests {
     fn test_show() {
         assert_eq!(format!("{}", SecStr::from("hello")), "***SECRET***".to_string());
     }
-
+    
+    #[test]
+    fn test_comparison_zero_out_mb() {
+        let mbstring1 = SecVec::from(vec!['H','a','l','l','o',' ','🦄','!']);
+        let mbstring2 = SecVec::from(vec!['H','a','l','l','o',' ','🦄','!']);
+        let mbstring3 = SecVec::from(vec!['!','🦄',' ','o','l','l','a','H']);
+        assert!(mbstring1 == mbstring2);
+        assert!(mbstring1 != mbstring3);
+        
+        let mut mbstring = mbstring1.clone();
+        mbstring.zero_out();
+        assert_eq!(mbstring.unsecure(), &['\0','\0','\0','\0','\0','\0','\0','\0']);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ unsafe fn memzero(pnt: *mut u8, len: libc::size_t) {
 #[inline(never)]
 #[cfg(not(feature = "libsodium-sys"))]
 unsafe fn memzero(pnt: *mut u8, len: libc::size_t) {
-    std::ptr::write_bytes(pnt as *mut libc::c_void, 0, len);
+    for i in 0 .. len {
+        std::ptr::write_volatile(pnt.offset(i as isize), 0);
+    }
 }
 
 #[cfg(feature = "libsodium-sys")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ impl<T> fmt::Display for SecBox<T> where T: Sized + Copy {
 
 #[cfg(test)]
 mod tests {
-    use super::{SecStr, SecVec};
+    use super::{SecBox, SecStr, SecVec};
     
     #[test]
     fn test_basic() {
@@ -336,5 +336,32 @@ mod tests {
         let mut mbstring = mbstring1.clone();
         mbstring.zero_out();
         assert_eq!(mbstring.unsecure(), &['\0','\0','\0','\0','\0','\0','\0','\0']);
+    }
+    
+    const PRIVATE_KEY_1: [u8; 32] = [
+        0xb0, 0x3b, 0x34, 0xc3, 0x3a, 0x1c, 0x44, 0xf2,
+        0x25, 0xb6, 0x62, 0xd2, 0xbf, 0x48, 0x59, 0xb8,
+        0x13, 0x54, 0x11, 0xfa, 0x7b, 0x03, 0x86, 0xd4,
+        0x5f, 0xb7, 0x5d, 0xc5, 0xb9, 0x1b, 0x44, 0x66];
+    
+    const PRIVATE_KEY_2: [u8; 32] = [
+        0xc8, 0x06, 0x43, 0x9d, 0xc9, 0xd2, 0xc4, 0x76,
+        0xff, 0xed, 0x8f, 0x25, 0x80, 0xc0, 0x88, 0x8d,
+        0x58, 0xab, 0x40, 0x6b, 0xf7, 0xae, 0x36, 0x98,
+        0x87, 0x90, 0x21, 0xb9, 0x6b, 0xb4, 0xbf, 0x59];
+    
+    #[test]
+    fn test_secbox() {
+        let key_1 = SecBox::new(Box::new(PRIVATE_KEY_1));
+        let key_2 = SecBox::new(Box::new(PRIVATE_KEY_2));
+        let key_3 = SecBox::new(Box::new(PRIVATE_KEY_1));
+        assert!(key_1 == key_1);
+        assert!(key_1 != key_2);
+        assert!(key_2 != key_3);
+        assert!(key_1 == key_3);
+        
+        let mut final_key = key_1.clone();
+        final_key.zero_out();
+        assert_eq!(final_key.unsecure(), &[0; 32]);
     }
 }


### PR DESCRIPTION
Based on #3.

Refactor `SecStr` into a generic `SecVec<T>` type and make `SecStr` a type alias for `SecVec<u8>`. Also add a similar `SecBox<T>` type that wraps a `Box` instead of a `Vec`.
