### PR TITLE
Fix some undefined behavior and check preconditions of `unsafe` code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,9 @@
+max_width = 128
+fn_call_width = 96
+struct_lit_width = 64
+struct_variant_width = 96
+array_width = 256
+newline_style = "Native"
+use_try_shorthand = true
+match_block_trailing_comma = true
+fn_call_style = "Block"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/myfreeweb/secstr"
 repository = "https://github.com/myfreeweb/secstr"
 documentation = "https://docs.rs/secstr/"
+edition = "2018"
 
 [lib]
 name = "secstr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ name = "secstr"
 [dependencies]
 libc = "0.2"
 libsodium-sys = { version = "0", optional = true }
+pre = { version = "=0.2", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
+pre = "=0.2"
 serde_cbor = "0.11"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Featuring:
 - formatting as `***SECRET***` to prevent leaking into logs
 - (optionally) using libsodium (through [sodiumoxide]'s [libsodium-sys]) for zeroing, comparison, and hashing (`std::hash::Hash`)
 - (optionally) de/serializable into anything [Serde] supports as a byte string
+- (optionally) compile-time checked [preconditions] for the public `unsafe` API
 
 [Rust]: https://www.rust-lang.org
 [securemem]: https://hackage.haskell.org/package/securemem
@@ -23,6 +24,7 @@ Featuring:
 [sodiumoxide]: https://crates.io/crates/sodiumoxide
 [libsodium-sys]: https://crates.io/crates/libsodium-sys
 [Serde]: https://serde.rs/
+[preconditions]: https://crates.io/crates/pre
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ let text_to_print = format!("{}", SecStr::from("hello")); // "***SECRET***"
 // (but you can force it)
 let mut my_sec = SecStr::from("hello");
 my_sec.zero_out();
-assert_eq!(my_sec.unsecure(), b"\x00\x00\x00\x00\x00");
+// (It also sets the length to 0)
+assert_eq!(my_sec.unsecure(), b"");
 ```
 
 Be careful with `SecStr::from`: if you have a borrowed string, it will be copied.  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@ fn size_of<T: Sized>(slice: &[T]) -> usize {
  * Create a slice reference from the given box reference
  */
 fn box_as_slice<T: Sized>(reference: &Box<T>) -> &[T] {
-    unsafe { std::slice::from_raw_parts(reference as &T, 1) }
+    std::slice::from_ref(reference)
 }
 
 /**
  * Create a slice reference from the given box reference
  */
 fn box_as_slice_mut<T: Sized + Copy>(reference: &mut Box<T>) -> &mut [T] {
-    unsafe { std::slice::from_raw_parts_mut(reference as &mut T, 1) }
+    std::slice::from_mut(reference)
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,8 @@
 //! A data type suitable for storing sensitive information such as passwords and private keys in memory, featuring constant time equality, mlock and zeroing out.
-extern crate core; // Needed by pre
-#[cfg(any(test, feature = "pre"))]
-extern crate pre;
-#[cfg(feature = "serde")] extern crate serde;
 use std::fmt;
 use std::borrow::{Borrow, BorrowMut};
 #[cfg(feature = "serde")] use serde::ser::{Serialize, Serializer};
 #[cfg(feature = "serde")] use serde::de::{self, Deserialize, Deserializer, Visitor};
-#[cfg(all(test, feature = "serde"))] extern crate serde_cbor;
 
 
 /**
@@ -30,7 +25,7 @@ fn box_as_slice<T: Sized>(reference: &Box<T>) -> &[T] {
 mod mem {
     extern crate libsodium_sys as sodium;
     use std;
-    use ::size_of;
+    use crate::size_of;
 
     #[cfg_attr(
         any(test, feature = "pre"),
@@ -116,7 +111,7 @@ mod mem {
 mod mem {
     use std;
 
-    use ::size_of;
+    use crate::size_of;
 
     #[cfg_attr(
         any(test, feature = "pre"),


### PR DESCRIPTION
Sorry it took so long, I had some unexpected complications while working on this.

closes #9
closes #15
closes #17
closes #20

Notable changes in this pull request:
- pre is now used to check and document usage of `unsafe` code (except for FFI).
- Some functions now work with raw pointers to avoid UB when a possibly invalid value is behind a reference.
- `mem::mlock`/`mem::munlock` now need mutable arguments, because `libc::madvice` uses a `*mut libc::c_void` pointer and changing from `*const` to `*mut` and using that pointer is undefined behavior.
- `SecVec::zero_out` now sets the length to `0` (this avoids making it `unsafe` like `zero_out_secbox`, which has no equivalent).

  This is technically a breaking change, however making the function `unsafe` would be too and the values in the `SecVec` would not be very interesting after a call to `zero_out_secbox` anyway.

  If you prefer to rather make it `unsafe` instead though, feel free to let me know and I'll change it.
- `SecBox::zero_out` is removed in favor of the `unsafe` function `zero_out_secbox`. Unfortunately due to an implementation detail in pre, it is not possible to add preconditions to methods (at least on stable), so I made it a freestanding function.
  
  If you'd rather have it be a method of `SecBox`, feel free to let me know and I'll change it to be that and remove the precondition from it.
- Documented the undefined behavior described in #20.