### PR TITLE
Add resize function to SecVec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,6 +1027,16 @@ mod tests {
     }
 
     #[test]
+    fn test_resize() {
+        let mut my_sec = SecVec::from([0, 1]);
+        assert_eq!(my_sec.unsecure().len(), 2);
+        my_sec.resize(1, 0);
+        assert_eq!(my_sec.unsecure().len(), 1);
+        my_sec.resize(16, 2);
+        assert_eq!(my_sec.unsecure(), &[0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
+    }
+
+    #[test]
     fn test_comparison() {
         assert_eq!(SecStr::from("hello"), SecStr::from("hello"));
         assert!(SecStr::from("hello") != SecStr::from("yolo"));


### PR DESCRIPTION
This PR adds a `resize` function to `SecVec`.

It basically works like this:
- it remembers the old (current) vector pointer and capacity
- it resizes the vector in-place through [`Vec::resize`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.resize)
- if the vector pointer changed, the old memory region is zeroed
- if the vector pointer or the capacity changed, the new memory region is secured

I believe this is a secure implementation, but please confirm this as my knowledge on this is lacking.

The vector zeroing logic has been extracted to a function, because the resize function makes use of it as well.

Fixes #22 