### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "secstr"
 
 [dependencies]
 libc = "0.2"
-libsodium-sys = { version = "0", optional = true }
+libsodium-sys = { version = "0.2", optional = true }
 pre = { version = "=0.2", optional = true }
 serde = { version = "1.0", optional = true }
 


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.